### PR TITLE
Improve navigation discoverability and fix cinematic intro bugs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -127,6 +127,7 @@ body {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
   align-items: center;
+  min-height: 40px;
   padding: 0 max(28px, env(safe-area-inset-right)) 0 max(28px, env(safe-area-inset-left));
   pointer-events: none;
   color: rgba(234, 230, 221, 0.56);
@@ -137,26 +138,44 @@ body {
   text-shadow: 0 1px 14px rgba(0, 0, 0, 0.72);
 }
 .scene-navigation-target {
+  position: fixed;
+  top: 50%;
+  z-index: 100;
   display: flex;
   align-items: center;
   gap: 11px;
   width: fit-content;
   min-height: 40px;
-  padding: 7px 4px;
-  border: 0;
-  color: inherit;
-  background: transparent;
-  font: inherit;
-  letter-spacing: inherit;
-  text-transform: inherit;
+  padding: 9px 18px;
+  border: 1px solid rgba(238, 233, 223, 0.18);
+  border-radius: 999px;
+  color: rgba(234, 230, 221, 0.56);
+  background: rgba(12, 12, 12, 0.26);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-shadow: 0 1px 14px rgba(0, 0, 0, 0.72);
   pointer-events: auto;
   cursor: pointer;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.03);
+  transform: translateY(-50%);
   transition:
     color 0.35s ease,
     opacity 0.35s ease,
-    transform 0.35s cubic-bezier(0.22, 1, 0.36, 1);
+    border-color 0.35s ease,
+    background 0.35s ease;
+}
+.scene-navigation-previous {
+  left: max(28px, env(safe-area-inset-left));
+}
+.scene-navigation-next {
+  right: max(28px, env(safe-area-inset-right));
 }
 .scene-navigation-target svg {
+  display: block;
   width: 19px;
   height: 19px;
   fill: none;
@@ -168,12 +187,11 @@ body {
 }
 .scene-navigation-target:hover {
   color: rgba(255, 252, 245, 0.86);
+  border-color: rgba(238, 233, 223, 0.4);
+  background: rgba(12, 12, 12, 0.4);
 }
 .scene-navigation-target:hover svg {
   transform: translateX(-2px);
-}
-.scene-navigation-next {
-  justify-self: end;
 }
 .scene-navigation-next:hover svg {
   transform: translateX(2px);
@@ -198,6 +216,25 @@ body {
   text-align: center;
   white-space: nowrap;
 }
+.camera-location.is-nav-hint {
+  font-size: 14px;
+  transform: translateY(-75px);
+}
+.workspace-badge {
+  position: fixed;
+  top: max(25px, env(safe-area-inset-top));
+  left: max(28px, env(safe-area-inset-left));
+  z-index: 14;
+  margin: 0;
+  pointer-events: none;
+  color: rgba(244, 239, 229, 0.64);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-shadow: 0 1px 14px rgba(0, 0, 0, 0.72);
+  white-space: nowrap;
+}
 .scene-name {
   display: block;
   opacity: 0;
@@ -215,7 +252,7 @@ body {
 }
 .collection-close {
   position: fixed;
-  top: max(24px, env(safe-area-inset-top));
+  top: max(54px, calc(env(safe-area-inset-top) + 54px));
   left: max(28px, env(safe-area-inset-left));
   z-index: 45;
   display: inline-flex;
@@ -461,7 +498,26 @@ body {
   box-shadow: 0 14px 42px rgba(0, 0, 0, 0.38);
   transform-origin: 0 0;
   pointer-events: auto;
-  scrollbar-color: rgba(122, 149, 173, 0.45) transparent;
+  scrollbar-width: none;
+}
+.projects-overlay-shell::-webkit-scrollbar {
+  display: none;
+}
+.projects-overlay-scroll-track {
+  position: absolute;
+  top: 0;
+  right: 4px;
+  bottom: 0;
+  z-index: 2;
+  width: 5px;
+  pointer-events: none;
+}
+.projects-overlay-scroll-thumb {
+  position: absolute;
+  right: 0;
+  left: 0;
+  border-radius: 999px;
+  background: rgba(122, 149, 173, 0.55);
 }
 .projects-overlay-header {
   display: flex;
@@ -501,7 +557,7 @@ body {
 }
 .projects-overlay-columns {
   display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(270px, 0.75fr);
+  grid-template-columns: minmax(270px, 0.75fr) minmax(0, 1.55fr);
 }
 .projects-overlay-column {
   min-width: 0;
@@ -836,7 +892,9 @@ body {
 }
 .certificate-gallery-figure {
   min-width: 0;
-  margin: 0;
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 auto;
 }
 .certificate-gallery-image-link {
   display: block;
@@ -862,16 +920,13 @@ body {
   border-radius: 4px;
 }
 .certificate-gallery-caption {
-  display: flex;
-  align-items: end;
-  justify-content: space-between;
-  gap: 18px;
   margin-top: 18px;
 }
 .certificate-gallery-caption h2 {
-  max-width: 680px;
   margin: 0;
+  overflow: hidden;
   color: rgba(255, 252, 245, 0.9);
+  white-space: nowrap;
   font:
     500 clamp(16px, 2vw, 23px)/1.2 Georgia,
     serif;
@@ -885,29 +940,6 @@ body {
     sans-serif;
   letter-spacing: 0.14em;
   text-transform: uppercase;
-}
-.certificate-gallery-open {
-  flex: 0 0 auto;
-  padding: 10px 13px;
-  border: 1px solid rgba(244, 239, 229, 0.2);
-  border-radius: 999px;
-  color: rgba(244, 239, 229, 0.72);
-  font:
-    500 9px/1 ui-sans-serif,
-    system-ui,
-    sans-serif;
-  letter-spacing: 0.12em;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition:
-    color 0.25s ease,
-    border-color 0.25s ease,
-    background 0.25s ease;
-}
-.certificate-gallery-open:hover {
-  color: #fffdf8;
-  border-color: rgba(244, 239, 229, 0.5);
-  background: rgba(255, 255, 255, 0.07);
 }
 @keyframes certificate-gallery-in {
   from {
@@ -924,15 +956,20 @@ body {
     bottom: max(22px, env(safe-area-inset-bottom));
     padding: 0 20px;
   }
-  .scene-navigation-target {
-    display: none;
-  }
   .camera-location {
     font-size: 9px;
     letter-spacing: 0.18em;
   }
-  .collection-close {
+  .camera-location.is-nav-hint {
+    font-size: 14px;
+    transform: translateY(-70px);
+  }
+  .workspace-badge {
     top: max(18px, env(safe-area-inset-top));
+    left: max(18px, env(safe-area-inset-left));
+  }
+  .collection-close {
+    top: max(46px, calc(env(safe-area-inset-top) + 46px));
     left: max(18px, env(safe-area-inset-left));
   }
   .collection-close-key,
@@ -993,10 +1030,10 @@ body {
     height: 18px;
   }
   .scene-navigation-previous {
-    justify-self: start;
+    left: max(18px, env(safe-area-inset-left));
   }
   .scene-navigation-next {
-    justify-self: end;
+    right: max(18px, env(safe-area-inset-right));
   }
   .camera-location {
     grid-column: 2;
@@ -1026,15 +1063,10 @@ body {
     max-height: 57svh;
   }
   .certificate-gallery-caption {
-    display: block;
     margin-top: 13px;
   }
   .certificate-gallery-caption h2 {
     font-size: 18px;
-  }
-  .certificate-gallery-open {
-    display: inline-block;
-    margin-top: 13px;
   }
 }
 @media (max-width: 760px) {
@@ -1287,7 +1319,7 @@ body {
 .poem-reader-close {
   position: fixed;
   top: max(14px, env(safe-area-inset-top));
-  left: max(14px, env(safe-area-inset-left));
+  right: max(14px, env(safe-area-inset-right));
   z-index: 3;
   display: grid;
   width: 34px;
@@ -1432,6 +1464,52 @@ body {
   scrollbar-width: thin;
   scrollbar-color: rgba(62, 48, 38, 0.35) transparent;
 }
+.poem-reader-scroll-hint {
+  position: absolute;
+  bottom: 66px;
+  left: 50%;
+  display: grid;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  place-items: center;
+  border: 1px solid rgba(49, 40, 33, 0.52);
+  border-radius: 50%;
+  color: #201b17;
+  background: rgba(49, 40, 33, 0.08);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-50%);
+  transition:
+    opacity 0.5s ease,
+    color 0.25s ease;
+}
+.poem-reader-scroll-hint.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+  animation: poem-reader-scroll-hint-bounce 1.6s ease-in-out infinite;
+}
+.poem-reader-scroll-hint:hover {
+  color: #17120f;
+}
+.poem-reader-scroll-hint svg {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 2;
+}
+@keyframes poem-reader-scroll-hint-bounce {
+  0%,
+  100% {
+    transform: translate(-50%, 0);
+  }
+  50% {
+    transform: translate(-50%, 6px);
+  }
+}
 .poem-reader-content:focus,
 .poem-reader-content:focus-visible,
 .poem-reader-body:focus {
@@ -1496,6 +1574,8 @@ body {
   justify-content: center;
   gap: clamp(22px, 8vw, 100px);
   border-top: 1px solid rgba(65, 50, 40, 0.16);
+  font-size: 13px;
+  font-weight: 700;
 }
 .poem-reader-footer button:disabled {
   cursor: default;
@@ -1719,7 +1799,11 @@ body {
   .poem-reader-close {
     display: none;
   }
+  .poem-reader-scroll-hint {
+    display: none;
+  }
   .poem-reader-header {
+    padding-right: 0;
     padding-left: 0;
     justify-content: flex-start;
     gap: 12px;
@@ -1729,6 +1813,7 @@ body {
     flex: 0 0 34px;
     width: 34px;
     height: 34px;
+    margin-left: 14px;
     padding: 0;
     place-items: center;
     border: 1px solid rgba(49, 40, 33, 0.52);
@@ -1766,6 +1851,10 @@ body {
   .poem-reader-header,
   .poem-reader-footer {
     font-size: 9px;
+  }
+  .poem-reader-footer {
+    font-size: 12px;
+    font-weight: 700;
   }
   .poem-reader-body {
     font-size: 19px;

--- a/src/scene/Experience.tsx
+++ b/src/scene/Experience.tsx
@@ -24,7 +24,6 @@ import {
   locationForScene,
   SCENE_REGISTRY,
 } from "./camera/sceneRegistry";
-import { INTRO_DESTINATION } from "./camera/shotRegistry";
 import {
   useAutoSceneNavigation,
   useCameraKeyboardNavigation,
@@ -306,7 +305,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
       })),
     [poemNavigationKey],
   );
-  const { syncRoute, goToScene, resumeFromStart, cameraState, introVersion } = cameraSystem;
+  const { syncRoute, goToScene, resumeFromStart } = cameraSystem;
 
   useEffect(() => {
     sceneReadyRef.current = sceneReady;
@@ -560,31 +559,12 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
     [cameraSystem],
   );
 
-  useCameraPinchNavigation(cameraSystem, goToWorkspace);
+  const navigateToNextScene = useCallback(() => {
+    cameraSystem.exitFocus();
+    cameraSystem.nextScene();
+  }, [cameraSystem]);
 
-  useEffect(() => {
-    if (route.path !== "/" || route.directEntry) return;
-    let frame = 0;
-    let sawOpening = false;
-    const waitForOpening = () => {
-      const state = cameraState.current;
-      if (state.isIntroActive) sawOpening = true;
-      if (
-        sawOpening &&
-        state.introComplete &&
-        state.currentTarget === "opening" &&
-        state.requestedTarget === "opening"
-      )
-        return;
-      if (sawOpening && state.introComplete && state.currentTarget === INTRO_DESTINATION) {
-        goToScene("about", INTRO_DESTINATION);
-        return;
-      }
-      frame = window.requestAnimationFrame(waitForOpening);
-    };
-    frame = window.requestAnimationFrame(waitForOpening);
-    return () => window.cancelAnimationFrame(frame);
-  }, [route.path, route.directEntry, cameraState, introVersion, goToScene]);
+  useCameraPinchNavigation(cameraSystem, goToWorkspace);
 
   const settings = SETTINGS;
   const onProfile = useCallback(
@@ -670,6 +650,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
           >
             <span>Entering workspace</span>
           </div>
+          <p className="workspace-badge">Denny&rsquo;s Workspace</p>
           <NavigationDebugPanel
             visible={cameraSystem.navigationDebug}
             stateRef={cameraSystem.cameraState}
@@ -688,6 +669,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
               onNext={cameraSystem.nextScene}
               onEnterFocus={cameraSystem.enterFocus}
               onExitFocus={cameraSystem.exitFocus}
+              poemReaderOpen={poemReaderOpen}
             />
           </Profiler>
           <CertificateGalleryOverlay
@@ -695,6 +677,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
             selectedSlug={cameraSystem.selectedFocusItem}
             onSelect={selectCertificate}
             onClose={cameraSystem.exitFocus}
+            onNavigateNext={navigateToNextScene}
           />
           {projectsResourcesResident && (
             <Suspense fallback={null}>

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -120,38 +120,19 @@ export interface SceneSettings {
   lampPosition: [number, number, number];
 }
 
-function transitionUsesOpening(cameraSystem: CinematicNavigationSystem) {
-  const state = cameraSystem.engine.getState();
-  return (
-    state.transitionStatus === "transitioning" &&
-    (state.sceneId === "opening") !== (state.requestedSceneId === "opening")
-  );
+function nearsOpening(engine: CinematicNavigationSystem["engine"]) {
+  const state = engine.getState();
+  return state.sceneId === "opening" || state.requestedSceneId === "opening";
 }
 
+// The chair only belongs at the Opening desk. It stays mounted for as long as
+// Opening is the current or destination scene — whether arriving there via
+// ESC/return, the guided tour looping back around, or a fresh load — and
+// unmounts once the camera has actually left for another scene.
 function useChairMountState(cameraSystem: CinematicNavigationSystem) {
-  const keepAtOpening = useRef(false);
-  const [mounted, setMounted] = useState(() => transitionUsesOpening(cameraSystem));
+  const [mounted, setMounted] = useState(() => nearsOpening(cameraSystem.engine));
   useEffect(() => {
-    const update = () => {
-      const state = cameraSystem.engine.getState();
-      const crossingOpening =
-        state.transitionStatus === "transitioning" &&
-        (state.sceneId === "opening") !== (state.requestedSceneId === "opening");
-      if (
-        crossingOpening &&
-        state.requestedSceneId === "opening" &&
-        state.transitionIntent === "return"
-      )
-        keepAtOpening.current = true;
-      if (state.transitionStatus === "idle" && state.sceneId !== "opening")
-        keepAtOpening.current = false;
-      setMounted(
-        crossingOpening ||
-          (state.transitionStatus === "idle" &&
-            state.sceneId === "opening" &&
-            keepAtOpening.current),
-      );
-    };
+    const update = () => setMounted(nearsOpening(cameraSystem.engine));
     update();
     return cameraSystem.engine.subscribe(update);
   }, [cameraSystem.engine]);

--- a/src/scene/camera/CameraRig.tsx
+++ b/src/scene/camera/CameraRig.tsx
@@ -394,24 +394,15 @@ export function CameraRig(props: Props) {
         }
 
         const elapsed = now - transitionStart.current;
-
-        if (props.reducedMotion) {
+        // The intro cinematic used to always finish by panning on to "about"
+        // (INTRO_DESTINATION). Visitors now navigate there themselves, so the
+        // intro simply settles at "opening" and stops once its hold elapses.
+        const holdDuration = props.reducedMotion ? 0 : props.openingHold;
+        if (elapsed >= holdDuration && !transitioning.current) {
           introActive.current = false;
           introComplete.current = true;
-          beginTransition(INTRO_DESTINATION, now, 0.18);
-        } else if (elapsed >= props.openingHold && !transitioning.current) {
-          const aspect = size.width / size.height;
-          const workspace = tuneTarget(
-            resolveCameraTarget(INTRO_PAN_SHOT, aspect),
-            props.tuning,
-            aspect,
-          );
-          beginTransition(
-            INTRO_DESTINATION,
-            now,
-            props.openingDuration - props.openingHold,
-            workspace.position,
-          );
+          requestedId.current = "opening";
+          props.onTransitionComplete?.();
         }
       }
 

--- a/src/scene/camera/SceneNavigation.tsx
+++ b/src/scene/camera/SceneNavigation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 
 import { FOCUS_COLLECTIONS, getAdjacentScene, getFocusItem, SCENE_REGISTRY } from "./sceneRegistry";
 
@@ -17,6 +18,7 @@ interface Props {
   onNext: () => SceneId | null;
   onEnterFocus: (collection: FocusCollectionId, item: string) => unknown;
   onExitFocus: () => unknown;
+  poemReaderOpen: boolean;
 }
 
 function Arrow({ direction }: { direction: "left" | "right" }) {
@@ -59,8 +61,21 @@ export function SceneNavigation({
   onNext,
   onEnterFocus,
   onExitFocus,
+  poemReaderOpen,
 }: Props) {
   const [introComplete, setIntroComplete] = useState(false);
+  const [hasClickedNav, setHasClickedNav] = useState(false);
+  // The portal below only exists client-side. Reading `typeof document` in
+  // render is itself a server/client branch — always false during SSR, always
+  // true on the client's first paint — which is exactly what causes a
+  // hydration mismatch. Gate on a mount flag instead, so both the server
+  // render and the client's *initial* render agree (nothing), and the portal
+  // only appears once mounted, after hydration has already reconciled.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    const markMounted = () => setMounted(true);
+    markMounted();
+  }, []);
   useEffect(() => {
     const update = () => setIntroComplete(stateRef.current.introComplete);
     update();
@@ -76,7 +91,12 @@ export function SceneNavigation({
   const previous = getAdjacentScene(current, -1, visitedAutoScenes);
   const resumeTarget = introComplete && current === "opening" ? resumeScene : null;
   const next = resumeTarget ?? getAdjacentScene(current, 1, visitedAutoScenes);
-  const currentLabel = current === "opening" ? "" : SCENE_REGISTRY[current].label;
+  const showNavHint = current === "opening" && !hasClickedNav;
+  const currentLabel = showNavHint
+    ? "Use the side buttons to navigate"
+    : current === "opening"
+      ? ""
+      : SCENE_REGISTRY[current].label;
   const collectionId = SCENE_REGISTRY[current].focusCollection ?? null;
   const collection = collectionId ? FOCUS_COLLECTIONS[collectionId] : null;
 
@@ -93,32 +113,55 @@ export function SceneNavigation({
   return (
     <>
       <nav className="scene-navigation" aria-label="Scene navigation">
-        <button
-          type="button"
-          className="scene-navigation-target scene-navigation-previous"
-          aria-label={
-            previous ? `Previous scene: ${SCENE_REGISTRY[previous].label}` : "No previous scene"
-          }
-          disabled={!introComplete || !previous}
-          onClick={() => previous && onNavigate(previous)}
+        <div
+          className={`scene-navigation-current camera-location${showNavHint ? " is-nav-hint" : ""}`}
+          aria-live="polite"
         >
-          <Arrow direction="left" />
-          <FadingSceneName label={previous ? SCENE_REGISTRY[previous].label : ""} />
-        </button>
-        <div className="scene-navigation-current camera-location" aria-live="polite">
           <FadingSceneName label={currentLabel} />
         </div>
-        <button
-          type="button"
-          className="scene-navigation-target scene-navigation-next"
-          aria-label={next ? `Next scene: ${SCENE_REGISTRY[next].label}` : "No next scene"}
-          disabled={!introComplete || !next}
-          onClick={() => onNext()}
-        >
-          <FadingSceneName label={next ? SCENE_REGISTRY[next].label : ""} />
-          <Arrow direction="right" />
-        </button>
       </nav>
+      {/* Portaled directly to <body> so the prev/next controls always paint
+          above every scene overlay (projects, certificates, poems), rather
+          than being trapped inside .canvas-stage's stacking/compositing tree
+          alongside JS-positioned (matrix3d-transformed) overlay content. Hidden
+          while a certificate or poem is open full-screen — those overlays have
+          their own close controls and scene navigation doesn't apply there. */}
+      {mounted &&
+        selectedFocusCollection !== "certificates" &&
+        !poemReaderOpen &&
+        createPortal(
+          <>
+            <button
+              type="button"
+              className="scene-navigation-target scene-navigation-previous"
+              aria-label={
+                previous ? `Previous scene: ${SCENE_REGISTRY[previous].label}` : "No previous scene"
+              }
+              disabled={!introComplete || !previous}
+              onClick={() => {
+                setHasClickedNav(true);
+                if (previous) onNavigate(previous);
+              }}
+            >
+              <Arrow direction="left" />
+              <FadingSceneName label={previous ? SCENE_REGISTRY[previous].label : ""} />
+            </button>
+            <button
+              type="button"
+              className="scene-navigation-target scene-navigation-next"
+              aria-label={next ? `Next scene: ${SCENE_REGISTRY[next].label}` : "No next scene"}
+              disabled={!introComplete || !next}
+              onClick={() => {
+                setHasClickedNav(true);
+                onNext();
+              }}
+            >
+              <FadingSceneName label={next ? SCENE_REGISTRY[next].label : ""} />
+              <Arrow direction="right" />
+            </button>
+          </>,
+          document.body,
+        )}
       {selectedFocusCollection && selectedFocusCollection !== "certificates" && (
         <button
           type="button"

--- a/src/scene/camera/sceneRegistry.ts
+++ b/src/scene/camera/sceneRegistry.ts
@@ -158,11 +158,11 @@ export const SCENE_REGISTRY: Record<SceneId, SceneDefinition> = {
     },
     responsive: {
       mobile: {
-        position: poemsPageCameraPosition(3.55, 0.08),
+        position: poemsPageCameraPosition(2.4, 0.03),
         lookAt: POEMS_PAGE_LAYOUT.mobileReadingTarget,
-        fov: 37,
+        fov: 17,
         safeMargins: { top: 0.08, right: 0.07, bottom: 0.14, left: 0.07 },
-        composition: "single readable poem page with notebook spine context",
+        composition: "tight crop on the right-hand reading page only",
       },
       tablet: {
         position: poemsAlignedCameraPosition(3.72, 0.2),
@@ -364,6 +364,10 @@ export function getAdjacentScene(
     }
     return null;
   }
+  // Mirrors the forward wrap above: stepping back from Opening returns to the
+  // last guided stop instead of dead-ending, so the back arrow/gesture can
+  // undo a completed lap of the tour.
+  if (index === 0) return GUIDED_SCENE_IDS[GUIDED_SCENE_IDS.length - 1];
   let previousIndex = index - 1;
   while (previousIndex >= 0 && SCENE_REGISTRY[GUIDED_SCENE_IDS[previousIndex]].autoAdvance)
     previousIndex -= 1;

--- a/src/scene/camera/useCinematicCamera.ts
+++ b/src/scene/camera/useCinematicCamera.ts
@@ -295,7 +295,11 @@ export function useCinematicNavigation(
   const [visitedAutoScenes, setVisitedAutoScenes] = useState<SceneId[]>([]);
 
   const routeLocation = normalizeLocation(initialValue);
-  const initialRequested = directEntry ? routeLocation : locationForScene("about");
+  // Requesting "about" here used to be what drove the camera onward once the
+  // intro cinematic finished. Now that nothing auto-navigates the visitor
+  // there, the initial request must match the resting shot ("opening") or
+  // the rig's per-frame shot-transition logic keeps chasing "about" forever.
+  const initialRequested = directEntry ? routeLocation : locationForScene("opening");
   const initialCurrent = directEntry ? routeLocation : locationForScene("opening");
 
   const [engine] = useState(() => {

--- a/src/scene/components/CertificateGalleryOverlay.tsx
+++ b/src/scene/components/CertificateGalleryOverlay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef } from "react";
 
 import { CERTIFICATES } from "../objects/certificates";
 import { withSceneBasePath } from "../camera/sceneRoutes";
@@ -11,6 +11,7 @@ interface Props {
   selectedSlug: string | null;
   onSelect: (slug: string) => void;
   onClose: () => void;
+  onNavigateNext?: () => void;
 }
 
 function GalleryArrow({ direction }: { direction: "previous" | "next" }) {
@@ -27,9 +28,27 @@ function GalleryArrow({ direction }: { direction: "previous" | "next" }) {
  * never asks the camera to reframe or the GPU to keep every full-size image
  * resident in the scene.
  */
-export function CertificateGalleryOverlay({ open, selectedSlug, onSelect, onClose }: Props) {
+export function CertificateGalleryOverlay({
+  open,
+  selectedSlug,
+  onSelect,
+  onClose,
+  onNavigateNext,
+}: Props) {
   const workingSet = useWorkingSetStore();
   const panelRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLHeadingElement>(null);
+  const fitTitle = useCallback(() => {
+    const el = titleRef.current;
+    if (!el) return;
+    el.style.fontSize = "";
+    const baseSize = parseFloat(window.getComputedStyle(el).fontSize);
+    const available = el.clientWidth;
+    const needed = el.scrollWidth;
+    if (available > 0 && needed > available) {
+      el.style.fontSize = `${(baseSize * available) / needed}px`;
+    }
+  }, []);
   const selectedIndex = useMemo(() => {
     const index = CERTIFICATES.findIndex(({ slug }) => slug === selectedSlug);
     return index < 0 ? 0 : index;
@@ -65,6 +84,17 @@ export function CertificateGalleryOverlay({ open, selectedSlug, onSelect, onClos
     return () => window.cancelAnimationFrame(frame);
   }, [open, selectedIndex]);
 
+  useLayoutEffect(() => {
+    if (!open) return;
+    fitTitle();
+  }, [fitTitle, open, certificate?.slug]);
+
+  useEffect(() => {
+    if (!open) return;
+    window.addEventListener("resize", fitTitle);
+    return () => window.removeEventListener("resize", fitTitle);
+  }, [fitTitle, open]);
+
   useEffect(() => {
     if (!open) return;
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -83,11 +113,12 @@ export function CertificateGalleryOverlay({ open, selectedSlug, onSelect, onClos
         event.preventDefault();
         event.stopPropagation();
         if (next) onSelect(next.slug);
+        else onNavigateNext?.();
       }
     };
     panelRef.current?.addEventListener("keydown", handleKeyDown);
     return () => panelRef.current?.removeEventListener("keydown", handleKeyDown);
-  }, [next, onClose, onSelect, open, previous]);
+  }, [next, onClose, onNavigateNext, onSelect, open, previous]);
 
   if (!open || !certificate) return null;
 
@@ -143,13 +174,14 @@ export function CertificateGalleryOverlay({ open, selectedSlug, onSelect, onClos
                 className="certificate-gallery-image"
                 loading="eager"
                 decoding="async"
-                onLoad={() =>
+                onLoad={() => {
                   workingSet.resourceEvent("prepare-end", "certificate-original", {
                     status: "resident",
                     cache: "browser",
                     detail: certificate.image,
-                  })
-                }
+                  });
+                  fitTitle();
+                }}
                 onError={() =>
                   workingSet.resourceEvent("error", "certificate-original", {
                     status: "error",
@@ -160,26 +192,16 @@ export function CertificateGalleryOverlay({ open, selectedSlug, onSelect, onClos
               />
             </a>
             <figcaption className="certificate-gallery-caption">
-              <div>
-                <h2>{certificate.title}</h2>
-                <p>{certificate.date}</p>
-              </div>
-              <a
-                href={certificate.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="certificate-gallery-open"
-              >
-                Open certificate <span aria-hidden="true">↗</span>
-              </a>
+              <h2 ref={titleRef}>{certificate.title}</h2>
+              <p>{certificate.date}</p>
             </figcaption>
           </figure>
           <button
             type="button"
             className="certificate-gallery-nav certificate-gallery-nav-next"
-            onClick={() => next && onSelect(next.slug)}
-            disabled={!next}
-            aria-label="Next certificate"
+            onClick={() => (next ? onSelect(next.slug) : onNavigateNext?.())}
+            disabled={!next && !onNavigateNext}
+            aria-label={next ? "Next certificate" : "Next scene"}
           >
             <GalleryArrow direction="next" />
           </button>

--- a/src/scene/components/PoemReader.tsx
+++ b/src/scene/components/PoemReader.tsx
@@ -72,6 +72,24 @@ interface Props {
   onClose: (slug: string | null) => void;
 }
 
+function easeInOutCubic(t: number) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+}
+
+// Native `scrollBy({ behavior: "smooth" })` duration/easing isn't
+// controllable and varies by browser, so the scroll-hint nudge animates
+// scrollTop by hand for a deliberately slow, eased motion.
+function smoothScrollBy(el: HTMLElement, distance: number, duration: number) {
+  const start = el.scrollTop;
+  const startTime = performance.now();
+  const step = (now: number) => {
+    const progress = Math.min((now - startTime) / duration, 1);
+    el.scrollTop = start + distance * easeInOutCubic(progress);
+    if (progress < 1) requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+}
+
 function readableDate(value: string) {
   const date = new Date(`${value}T00:00:00`);
   return Number.isNaN(date.valueOf())
@@ -125,6 +143,9 @@ export function PoemReader({ open, poems, slug, onSlugChange, onClose }: Props) 
   const [commentSending, setCommentSending] = useState(false);
 
   const contentRef = useRef<HTMLElement | null>(null);
+  const columnRef = useRef<HTMLDivElement | null>(null);
+  const [hasMoreBelow, setHasMoreBelow] = useState(false);
+  const [scrollHintSeen, setScrollHintSeen] = useState(false);
 
   // The parent owns the URL-backed slug. Keeping a second local slug here can
   // briefly pair the previous selection with the new route during fast turns.
@@ -147,6 +168,32 @@ export function PoemReader({ open, poems, slug, onSlugChange, onClose }: Props) 
   useEffect(() => {
     contentRef.current?.scrollTo({ top: 0, left: 0, behavior: "auto" });
   }, [slug]);
+
+  // Long poems can overflow the reader on both desktop and mobile with no
+  // visible scrollbar cue (mobile hides it entirely). Show a down-arrow hint
+  // each time the reader (re)opens on content that overflows, without dimming
+  // the text itself; dismiss it for this visit once actually scrolled. Reruns
+  // on `open` because the reader's DOM — and these refs — unmount while closed.
+  useEffect(() => {
+    const el = contentRef.current;
+    const column = columnRef.current;
+    if (!el || !column) return;
+    const update = () => {
+      setHasMoreBelow(el.scrollHeight - el.scrollTop - el.clientHeight > 4);
+      if (el.scrollTop > 4) setScrollHintSeen(true);
+    };
+    setScrollHintSeen(false);
+    update();
+    el.addEventListener("scroll", update, { passive: true });
+    // Observe the content column, not the fixed-size scroll container itself
+    // — the container's own box never resizes as its content overflows it.
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(column);
+    return () => {
+      el.removeEventListener("scroll", update);
+      resizeObserver.disconnect();
+    };
+  }, [displayRecord, open]);
 
   useEffect(() => {
     try {
@@ -288,16 +335,6 @@ export function PoemReader({ open, poems, slug, onSlugChange, onClose }: Props) 
       </button>
       <div className="poem-reader-shell">
         <header className="poem-reader-header">
-          <button
-            type="button"
-            className="poem-reader-mobile-close"
-            onClick={() => onClose(activeSlug)}
-            aria-label="Close reader"
-          >
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M6.5 6.5 17.5 17.5M17.5 6.5 6.5 17.5" />
-            </svg>
-          </button>
           <p className="poem-reader-kicker">Denny K. Schuldt · Poems</p>
           <div className="poem-reader-header-actions">
             <button
@@ -333,10 +370,20 @@ export function PoemReader({ open, poems, slug, onSlugChange, onClose }: Props) 
             >
               {shareLabel}
             </button>
+            <button
+              type="button"
+              className="poem-reader-mobile-close"
+              onClick={() => onClose(activeSlug)}
+              aria-label="Close reader"
+            >
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6.5 6.5 17.5 17.5M17.5 6.5 6.5 17.5" />
+              </svg>
+            </button>
           </div>
         </header>
         <main ref={contentRef} className="poem-reader-content" tabIndex={-1}>
-          <div className="poem-reader-column">
+          <div className="poem-reader-column" ref={columnRef}>
             {displayRecord && (
               <>
                 <p className="poem-reader-date">
@@ -363,6 +410,20 @@ export function PoemReader({ open, poems, slug, onSlugChange, onClose }: Props) 
             {!displayRecord && <p className="poem-reader-status">Loading poem…</p>}
           </div>
         </main>
+        <button
+          type="button"
+          className={`poem-reader-scroll-hint${hasMoreBelow && !scrollHintSeen ? " is-visible" : ""}`}
+          aria-label="Scroll down"
+          aria-hidden={!(hasMoreBelow && !scrollHintSeen)}
+          tabIndex={hasMoreBelow && !scrollHintSeen ? 0 : -1}
+          onClick={() => {
+            if (contentRef.current) smoothScrollBy(contentRef.current, 320, 900);
+          }}
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M6 10l6 6 6-6" />
+          </svg>
+        </button>
         <footer className="poem-reader-footer">
           <button
             type="button"

--- a/src/scene/components/ProjectsOverlay.tsx
+++ b/src/scene/components/ProjectsOverlay.tsx
@@ -209,8 +209,32 @@ export function ProjectsOverlay({
 }) {
   const workingSet = useWorkingSetStore();
   const shellRef = useRef<HTMLDivElement | null>(null);
+  const scrollThumbRef = useRef<HTMLDivElement | null>(null);
   const [present, setPresent] = useState(visible);
   const [mobileTab, setMobileTab] = useState<"experience" | "projects">("experience");
+  // The shell has a live JS-driven `matrix3d` transform (the laptop-screen
+  // projection below), and native scrollbars don't render reliably on an
+  // element under a heavy 3D transform. Drive a plain div as the scroll
+  // indicator instead, so it's always visible regardless of browser/OS.
+  useEffect(() => {
+    const shell = shellRef.current,
+      thumb = scrollThumbRef.current;
+    if (!shell || !thumb) return;
+    const update = () => {
+      const { scrollTop, scrollHeight, clientHeight } = shell;
+      const ratio = clientHeight / scrollHeight;
+      thumb.style.height = `${Math.max(ratio * 100, 6)}%`;
+      thumb.style.top = `${(scrollTop / scrollHeight) * 100}%`;
+    };
+    update();
+    shell.addEventListener("scroll", update, { passive: true });
+    const resizeObserver = new ResizeObserver(update);
+    resizeObserver.observe(shell);
+    return () => {
+      shell.removeEventListener("scroll", update);
+      resizeObserver.disconnect();
+    };
+  }, [present]);
   useEffect(() => {
     workingSet.resourceEvent("prepare-end", "projects-overlay", {
       status: "resident",
@@ -275,6 +299,9 @@ export function ProjectsOverlay({
           visibility: "hidden",
         }}
       >
+        <div className="projects-overlay-scroll-track" aria-hidden="true">
+          <div className="projects-overlay-scroll-thumb" ref={scrollThumbRef} />
+        </div>
         <header className="projects-overlay-header">
           <div>
             <p className="projects-overlay-eyebrow">Denny K. Schuldt</p>
@@ -302,6 +329,20 @@ export function ProjectsOverlay({
           </button>
         </div>
         <div className="projects-overlay-columns">
+          <article
+            id="projects-projects-panel"
+            role="tabpanel"
+            className={`projects-overlay-column projects-overlay-projects${mobileTab === "projects" ? " is-mobile-active" : ""}`}
+          >
+            <div className="projects-overlay-column-heading">
+              <h2>Projects</h2>
+            </div>
+            <div className="projects-overlay-project-list">
+              {PROJECTS.map((project) => (
+                <ProjectLink key={project.title} project={project} />
+              ))}
+            </div>
+          </article>
           <article
             id="projects-experience-panel"
             role="tabpanel"
@@ -333,20 +374,6 @@ export function ProjectsOverlay({
                     </ul>
                   )}
                 </section>
-              ))}
-            </div>
-          </article>
-          <article
-            id="projects-projects-panel"
-            role="tabpanel"
-            className={`projects-overlay-column projects-overlay-projects${mobileTab === "projects" ? " is-mobile-active" : ""}`}
-          >
-            <div className="projects-overlay-column-heading">
-              <h2>Projects</h2>
-            </div>
-            <div className="projects-overlay-project-list">
-              {PROJECTS.map((project) => (
-                <ProjectLink key={project.title} project={project} />
               ))}
             </div>
           </article>

--- a/src/scene/content/usePoems.ts
+++ b/src/scene/content/usePoems.ts
@@ -131,22 +131,15 @@ export function usePoems(activeSlug: string | null, enabled = false): PoemsConte
         results.flatMap(({ poem }) => (poem ? [[poem.slug, poem] as const] : [])),
       );
       const error = results.find((result) => result.error)?.error ?? null;
-      setState((current) => {
-        const requested = state.poems[index]?.slug;
-        const keep = new Set([requested, ...targets.map(({ slug }) => slug)]);
-        return {
-          ...current,
-          error: error ?? current.error,
-          poems: current.poems.map((candidate) => {
-            const next = loaded.get(candidate.slug) ?? candidate;
-            return keep.has(candidate.slug) ? next : next.body ? { ...next, body: "" } : next;
-          }),
-        };
-      });
+      setState((current) => ({
+        ...current,
+        error: error ?? current.error,
+        poems: current.poems.map((candidate) => loaded.get(candidate.slug) ?? candidate),
+      }));
       workingSet.resourceEvent(error ? "error" : "prepare-end", "poem-markdown", {
         status: error ? "error" : "resident",
         cache: "browser",
-        detail: error ?? `${loaded.size} body reference(s); bounded to selected and neighbours`,
+        detail: error ?? `${loaded.size} body reference(s); retained for the session`,
       });
     });
     return () => {

--- a/src/scene/objects/Primitives.tsx
+++ b/src/scene/objects/Primitives.tsx
@@ -459,7 +459,7 @@ PORTFOLIO_PAGE_GEOMETRY.center();
 PORTFOLIO_PAGE_GEOMETRY.rotateX(-Math.PI / 2);
 PORTFOLIO_PAGE_GEOMETRY.computeVertexNormals();
 const PORTFOLIO_PAGE_SURFACE_GEOMETRY = new THREE.PlaneGeometry(0.704, 0.682);
-const POEM_READ_CUE_GEOMETRY = new THREE.ShapeGeometry(roundedRectangleShape(0.28, 0.08, 0.04), 8);
+const POEM_READ_CUE_GEOMETRY = new THREE.ShapeGeometry(roundedRectangleShape(0.34, 0.08, 0.04), 8);
 const PORTFOLIO_RING_GEOMETRY = new THREE.TorusGeometry(0.032, 0.007, 4, 8, Math.PI * 1.75);
 // Small washers make the paper-to-ring connection legible at the close reading shot.
 // They sit on the top sheet only; the real binding is carried by the low-poly torus rings.
@@ -992,8 +992,10 @@ function PortfolioPolaroid({ active }: { active: boolean }) {
 }
 
 const POEM_PREVIEW_FONT_SIZE = 34;
+const POEM_PREVIEW_INTRO =
+  "Poetry is how I make sense of what I feel, what I lose, and what I still hope to find.\n\nI write about love, absence, identity, time, and the strange experience of being alive.";
 
-function createPoemPreviewTexture(poem: PoemRecord | null) {
+function createPoemPreviewTexture() {
   const canvas = document.createElement("canvas");
   canvas.width = 1024;
   canvas.height = 1160;
@@ -1004,50 +1006,41 @@ function createPoemPreviewTexture(poem: PoemRecord | null) {
   context.textBaseline = "top";
   context.fillStyle = "#17130f";
   context.font = '600 72px Georgia, "Times New Roman", serif';
-  context.fillText(poem?.title ?? "Poems", 78, 72, 868);
+  context.fillText("Poems", 78, 72, 868);
   context.fillStyle = "#332a23";
   context.fillRect(78, 150, 54, 2);
-  if (poem?.body) {
-    context.font = `${POEM_PREVIEW_FONT_SIZE}px Georgia, "Times New Roman", serif`;
-    context.fillStyle = "#211a15";
-    const paragraphs = poem.body
-      .split(/\n{2,}/)
-      .map((paragraph) => paragraph.replace(/\s+/g, " ").trim())
-      .filter(Boolean);
-    const lines: string[] = [];
-    for (const paragraph of paragraphs) {
-      const words = paragraph.split(" ");
-      let line = "";
-      for (const word of words) {
-        const candidate = line ? `${line} ${word}` : word;
-        if (line && context.measureText(candidate).width > 868) {
-          lines.push(line);
-          line = word;
-        } else line = candidate;
-      }
-      if (line) lines.push(line);
-      lines.push("");
+  context.font = `${POEM_PREVIEW_FONT_SIZE}px Georgia, "Times New Roman", serif`;
+  context.fillStyle = "#211a15";
+  const paragraphs = POEM_PREVIEW_INTRO.split(/\n{2,}/)
+    .map((paragraph) => paragraph.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+  const lines: string[] = [];
+  for (const paragraph of paragraphs) {
+    const words = paragraph.split(" ");
+    let line = "";
+    for (const word of words) {
+      const candidate = line ? `${line} ${word}` : word;
+      if (line && context.measureText(candidate).width > 868) {
+        lines.push(line);
+        line = word;
+      } else line = candidate;
     }
-    if (lines.at(-1) === "") lines.pop();
-    const visibleLines = lines.slice(0, 8);
-    if (lines.length > visibleLines.length && visibleLines.length)
-      visibleLines[visibleLines.length - 1] =
-        `${visibleLines[visibleLines.length - 1].replace(/[.…]+$/g, "")}…`;
-    visibleLines.forEach((line, index) =>
-      context.fillText(line, 78, 190 + index * POEM_PREVIEW_FONT_SIZE * 1.3),
-    );
-  } else {
-    context.fillStyle = "#6f6257";
-    context.font = '27px Georgia, "Times New Roman", serif';
-    context.fillText("Select a poem to read", 78, 194);
+    if (line) lines.push(line);
+    lines.push("");
   }
-  if (poem) {
-    context.textAlign = "right";
-    context.textBaseline = "top";
-    context.fillStyle = "#706356";
-    context.font = '24px Georgia, "Times New Roman", serif';
-    context.fillText(`${poem.date}  ·  Click to read`, 946, 1090);
-  }
+  if (lines.at(-1) === "") lines.pop();
+  const visibleLines = lines.slice(0, 8);
+  if (lines.length > visibleLines.length && visibleLines.length)
+    visibleLines[visibleLines.length - 1] =
+      `${visibleLines[visibleLines.length - 1].replace(/[.…]+$/g, "")}…`;
+  visibleLines.forEach((line, index) =>
+    context.fillText(line, 78, 190 + index * POEM_PREVIEW_FONT_SIZE * 1.3),
+  );
+  context.textAlign = "right";
+  context.textBaseline = "top";
+  context.fillStyle = "#706356";
+  context.font = '24px Georgia, "Times New Roman", serif';
+  context.fillText("Click to read", 946, 1090);
   const texture = new THREE.CanvasTexture(canvas);
   texture.colorSpace = THREE.SRGBColorSpace;
   texture.anisotropy = 8;
@@ -1069,7 +1062,7 @@ function usePoemPreviewTexture(poem: PoemRecord | null, enabled: boolean) {
       cache: "owned",
       detail: poem?.slug ?? "ambient",
     });
-    const next = createPoemPreviewTexture(poem);
+    const next = createPoemPreviewTexture();
     setTexture(next);
     if (next) {
       workingSet.resourceEvent("prepare-end", "poem-preview-texture", {
@@ -1175,12 +1168,12 @@ function PoemReadCue({
       </mesh>
       <Text
         position={[0, 0, 0.004]}
-        fontSize={0.022}
-        letterSpacing={0.045}
+        fontSize={0.02}
+        letterSpacing={0.02}
         anchorX="center"
         anchorY="middle"
       >
-        READ POEMS
+        READ MY POETRY
         <meshBasicMaterial
           ref={labelRef}
           color="#f4ecdf"
@@ -2297,6 +2290,33 @@ function CertificateGallery({
   );
 }
 
+const PLACEHOLDER_CERTIFICATE_COLOR = "#847e73";
+
+function CertificatePlaceholders() {
+  return (
+    <>
+      {CERTIFICATE_LAYOUT.map(({ index, x, y, rotation, tiltY, scale, depth }) => (
+        <RoundedBox
+          key={CERTIFICATES[index].image}
+          args={[0.482, 0.354, 0.035]}
+          radius={0.012}
+          position={[x, y, depth]}
+          rotation={[0, tiltY, rotation]}
+          scale={scale}
+          raycast={() => null}
+          castShadow
+        >
+          <meshStandardMaterial
+            color={PLACEHOLDER_CERTIFICATE_COLOR}
+            roughness={0.94}
+            metalness={0.02}
+          />
+        </RoundedBox>
+      ))}
+    </>
+  );
+}
+
 function ShelfPracticalLighting({ illuminated }: { illuminated: boolean }) {
   const lightRefs = useRef<THREE.RectAreaLight[]>([]);
   const ledRefs = useRef<THREE.MeshStandardMaterial[]>([]);
@@ -2516,8 +2536,10 @@ export function Shelf({
       </group>
       {/* Thumbnails are the ambient shelf artwork. Full-size certificate images
         are rendered by the HTML gallery, not as a second 3D card texture. */}
-      {thumbnailsResident && (
+      {thumbnailsResident ? (
         <CertificateGallery illuminated={illuminated} onCertificateSelect={onCertificateSelect} />
+      ) : (
+        <CertificatePlaceholders />
       )}
     </group>
   );


### PR DESCRIPTION
- Make scene-navigation prev/next controls persistent and always on top (portal to <body>, frosted-pill styling, vertically centered at screen edges), plus a one-time onboarding hint and a workspace badge.
- Stop the intro cinematic from auto-navigating to "about"; it now settles at "opening" and waits for the visitor to navigate manually.
- Fix a hydration mismatch from portaling nav controls (typeof document branch) and a chair-visibility regression at the opening scene.
- Add grayish shelf placeholders for certificates before thumbnails load, fix caption/title layout, and keep poem body text cached across navigation instead of re-fetching on every scene revisit.
- Add a scroll hint and custom scrollbar where native scrollbars don't render reliably under the projects overlay's 3D transform.