### PR TITLE
Move poems text to an HTML overlay and tune mobile framing/lighting

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -848,6 +848,73 @@ body {
 .about-overlay-shell a:hover {
   text-decoration-color: currentcolor;
 }
+.poems-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 34;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  pointer-events: none;
+  animation: overlay-fade-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+.poems-overlay.is-exiting {
+  animation: overlay-fade-out 0.48s cubic-bezier(0.65, 0, 0.35, 1) both;
+}
+.poems-overlay.is-exiting .poems-overlay-shell {
+  pointer-events: none;
+}
+.poems-overlay-shell {
+  position: fixed;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow: hidden;
+  padding: 40px 36px;
+  background: transparent;
+  color: #14110c;
+  font-family: "Patrick Hand", "Roboto", cursive;
+  transform-origin: 0 0;
+  pointer-events: auto;
+}
+.poems-overlay-shell h1 {
+  margin: 0 0 18px;
+  font-size: 56px;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+.poems-overlay-shell p {
+  margin: 0 0 20px;
+  font-size: 27px;
+  font-weight: 400;
+  line-height: 1.22;
+  font-family: "Coming Soon", "Patrick Hand", cursive;
+}
+.poems-overlay-read-button {
+  margin-top: auto;
+  align-self: center;
+  padding: 16px 34px;
+  border: none;
+  border-radius: 999px;
+  background: #2b211b;
+  color: #f4ecdf;
+  font-family: "Roboto", "Helvetica Neue", Arial, sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background-color 0.2s ease,
+    transform 0.2s ease;
+}
+.poems-overlay-read-button:hover {
+  background: #3a2d24;
+  transform: scale(1.04);
+}
 /* Homography-projected onto the polaroid card (see PolaroidCaptionOverlay
    and PolaroidPhoto's tracking mesh in objects/Primitives.tsx) — the
    caption strip below the photo, matching the paper's handwritten look.
@@ -1183,10 +1250,13 @@ body {
   }
   .scene-navigation-target {
     display: grid;
+    top: auto;
+    bottom: 25%;
     width: 44px;
     min-height: 44px;
     padding: 0;
     place-items: center;
+    transform: none;
     /* Without the "Previous/Next scene" text label (hidden below on
        mobile), a faint outline circle doesn't read as a tappable control on
        its own — noticeably more opaque/bordered than the desktop version,
@@ -1236,7 +1306,11 @@ body {
   }
   .photo-lightbox-content {
     flex-direction: column;
+    align-items: center;
     gap: 20px;
+  }
+  .photo-lightbox-socials {
+    padding: 0 24px;
   }
   .photo-lightbox-socials ul {
     flex-direction: row;
@@ -1410,16 +1484,33 @@ body {
     font-size: 19px;
   }
   .about-overlay-shell {
-    padding: 64px 46px 80px;
+    overflow: hidden;
+    padding: 30px 24px 34px;
   }
   .about-overlay-shell h1 {
-    margin-bottom: 26px;
-    font-size: 76px;
+    margin-bottom: 12px;
+    font-size: 30px;
   }
   .about-overlay-shell p {
-    margin-bottom: 34px;
-    font-size: 46px;
-    line-height: 1.24;
+    margin-bottom: 14px;
+    font-size: 28px;
+    line-height: 1.2;
+  }
+  .poems-overlay-shell {
+    padding: 56px 46px;
+  }
+  .poems-overlay-shell h1 {
+    margin-bottom: 22px;
+    font-size: 64px;
+  }
+  .poems-overlay-shell p {
+    margin-bottom: 24px;
+    font-size: 40px;
+    line-height: 1.26;
+  }
+  .poems-overlay-read-button {
+    padding: 22px 40px;
+    font-size: 20px;
   }
 }
 @media (prefers-reduced-motion: reduce) {
@@ -1793,6 +1884,9 @@ body {
 }
 .poem-comment-dialog {
   z-index: 80;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   color: #2a211b;
   font-family: ui-sans-serif, system-ui, sans-serif;
 }
@@ -1800,6 +1894,8 @@ body {
   box-sizing: border-box;
   width: 480px;
   min-width: 480px;
+  max-width: calc(100vw - 32px);
+  margin: 0 !important;
   padding: 28px 0;
 }
 .poem-comment-dialog .dnk-dialog-content-wrapper .dnk-dialog-content {
@@ -2041,6 +2137,9 @@ body {
     text-overflow: ellipsis;
     white-space: nowrap;
   }
+  .poem-reader-kicker-full {
+    display: none;
+  }
 }
 @media (max-width: 640px) {
   .poem-reader-shell {
@@ -2066,16 +2165,23 @@ body {
     line-height: 1.62;
   }
   .poem-comment-dialog .dnk-dialog-content-wrapper {
-    width: min(480px, calc(100vw - 36px));
-    min-width: min(480px, calc(100vw - 36px));
+    width: calc(100vw - 36px);
+    min-width: 0;
     padding: 18px 0;
   }
   .poem-comment-dialog .dnk-dialog-content-wrapper .dnk-dialog-content {
-    width: min(480px, calc(100vw - 36px));
-    min-width: min(480px, calc(100vw - 36px));
+    width: 100%;
+    min-width: 0;
+    /* react-draggable sets an inline transform: translate(x, y) on this
+       element that persists across opens once the dialog has been dragged.
+       Only a mouse-driven drag makes sense as an interaction, so on touch
+       viewports pin it centered regardless of any carried-over drag offset.
+       Overriding an inline style requires !important — normal specificity
+       can't win here. */
+    transform: none !important;
   }
   .poem-comment-dialog .dnk-dialog-content-wrapper .dnk-dialog-body {
-    min-width: min(480px, calc(100vw - 36px));
+    min-width: 0;
   }
   .poem-comment-dialog .dnk-dialog-header {
     padding: 21px 22px 8px;

--- a/src/scene/Experience.tsx
+++ b/src/scene/Experience.tsx
@@ -83,6 +83,9 @@ const ProjectsOverlay = lazy(() =>
 const AboutOverlay = lazy(() =>
   import("./components/AboutOverlay").then((module) => ({ default: module.AboutOverlay })),
 );
+const PoemsOverlay = lazy(() =>
+  import("./components/PoemsOverlay").then((module) => ({ default: module.PoemsOverlay })),
+);
 const PolaroidCaptionOverlay = lazy(() =>
   import("./components/PolaroidCaptionOverlay").then((module) => ({
     default: module.PolaroidCaptionOverlay,
@@ -200,14 +203,19 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
   const [projectsOverlayReady, setProjectsOverlayReady] = useState(false);
   const [aboutCameraFocused, setAboutCameraFocused] = useState(false);
   const [aboutOverlayReady, setAboutOverlayReady] = useState(false);
+  const [poemsCameraFocused, setPoemsCameraFocused] = useState(false);
+  const [poemsOverlayReady, setPoemsOverlayReady] = useState(false);
   const [poemReaderOpen, setPoemReaderOpen] = useState(false);
   const [readerPoemSlug, setReaderPoemSlug] = useState<string | null>(null);
-  const [photoLightboxOpen, setPhotoLightboxOpen] = useState(false);
+  const [photoLightboxOpen, setPhotoLightboxOpen] = useState(() =>
+    /^\/about\/socials\/?$/.test(initialPath),
+  );
 
   const directPoemEntry = useRef(/^\/poems\/[^/]+(?:\/)?$/.test(initialPath));
   const directPoemOpened = useRef(false);
   const previousProjectsScene = useRef<SceneId | null>(null);
   const previousAboutScene = useRef<SceneId | null>(null);
+  const previousPoemsScene = useRef<SceneId | null>(null);
   const lastCertificateVisit = useRef<string | null>(null);
   const lastPoemRead = useRef<string | null>(null);
   const sceneReadyRef = useRef(false);
@@ -220,6 +228,8 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
   const paperProjectionRef = useRef<ScreenProjection | null>(null);
   const polaroidScreenRef = useRef<THREE.Mesh | null>(null);
   const polaroidProjectionRef = useRef<ScreenProjection | null>(null);
+  const poemsScreenRef = useRef<THREE.Mesh | null>(null);
+  const poemsProjectionRef = useRef<ScreenProjection | null>(null);
 
   useEffect(() => {
     if (mixpanelInitialized || process.env.NODE_ENV !== "production") return;
@@ -305,8 +315,15 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
       ...(cameraSystem.selectedFocusCollection === "certificates" ? ["certificate-original"] : []),
       ...(projectsOverlayReady ? ["projects-overlay"] : []),
       ...(aboutOverlayReady ? ["about-overlay"] : []),
+      ...(poemsOverlayReady ? ["poems-overlay"] : []),
     ],
-    [poemReaderOpen, cameraSystem.selectedFocusCollection, projectsOverlayReady, aboutOverlayReady],
+    [
+      poemReaderOpen,
+      cameraSystem.selectedFocusCollection,
+      projectsOverlayReady,
+      aboutOverlayReady,
+      poemsOverlayReady,
+    ],
   );
   const poemNavigationKey = poemsContent.poems
     .map(
@@ -352,6 +369,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
     const unsubscribe = cameraSystem.engine.onSceneFocused((state) => {
       setProjectsCameraFocused(state.sceneId === "projects" && state.cameraTargetId === "projects");
       setAboutCameraFocused(state.sceneId === "about" && state.cameraTargetId === "about");
+      setPoemsCameraFocused(state.sceneId === "poems" && state.cameraTargetId === "poems");
       if (skippedSceneFocus.current) {
         skippedSceneFocus.current = false;
         pendingSceneFocus.current = null;
@@ -470,6 +488,24 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
   }, [cameraSystem.selectedScene]);
 
   useEffect(() => {
+    setPoemsOverlayReady(
+      sceneReady &&
+        cameraSystem.selectedScene === "poems" &&
+        poemsCameraFocused &&
+        cinematicFadeReady,
+    );
+  }, [cameraSystem.selectedScene, poemsCameraFocused, cinematicFadeReady, sceneReady]);
+
+  useEffect(() => {
+    const previous = previousPoemsScene.current;
+    previousPoemsScene.current = cameraSystem.selectedScene;
+    if (previous !== null && previous !== cameraSystem.selectedScene) {
+      setPoemsCameraFocused(false);
+      setPoemsOverlayReady(false);
+    }
+  }, [cameraSystem.selectedScene]);
+
+  useEffect(() => {
     setCinematicFadeReady(false);
   }, [cameraSystem.introVersion, cameraSystem.skipVersion]);
 
@@ -583,6 +619,26 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
     }
   }, [cameraSystem, replaceWithinScene]);
 
+  const openPhotoLightbox = useCallback(() => {
+    setPhotoLightboxOpen(true);
+    // Shareable like the poem reader's slug above — clicking the polaroid
+    // is one of two ways in (the other being a direct visit to the URL).
+    if (routeScene === "about") replaceWithinScene("/about/socials");
+  }, [routeScene, replaceWithinScene]);
+
+  const closePhotoLightbox = useCallback(() => {
+    setPhotoLightboxOpen(false);
+    if (routeScene === "about" && route.slug === "socials")
+      replaceWithinScene(pathForScene("about"));
+  }, [routeScene, route.slug, replaceWithinScene]);
+
+  useEffect(() => {
+    // Keeps the lightbox in sync with direct links to /about/socials and
+    // with browser back/forward while still on the about scene.
+    if (routeScene !== "about") return;
+    setPhotoLightboxOpen(route.slug === "socials");
+  }, [routeScene, route.slug]);
+
   useCameraKeyboardNavigation(cameraSystem, navigateScene);
   useCameraTapNavigation(cameraSystem, navigateScene);
   useAutoSceneNavigation(cameraSystem, navigateScene);
@@ -669,8 +725,6 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
                     s={settings}
                     cameraSystem={cameraSystem}
                     certificateSlug={route.slug}
-                    poemsContent={poemsContent}
-                    onPoemRead={openPoemReader}
                     renderIsolation={renderIsolation}
                     qualityProfile={qualityProfile}
                     qualityFeatures={qualityFeatures}
@@ -681,7 +735,9 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
                     paperProjectionRef={paperProjectionRef}
                     polaroidScreenRef={polaroidScreenRef}
                     polaroidProjectionRef={polaroidProjectionRef}
-                    onPhotoOpen={() => setPhotoLightboxOpen(true)}
+                    poemsScreenRef={poemsScreenRef}
+                    poemsProjectionRef={poemsProjectionRef}
+                    onPhotoOpen={openPhotoLightbox}
                   />
                 </Suspense>
               </Profiler>
@@ -714,6 +770,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
               onEnterFocus={cameraSystem.enterFocus}
               onExitFocus={cameraSystem.exitFocus}
               poemReaderOpen={poemReaderOpen}
+              photoLightboxOpen={photoLightboxOpen}
             />
           </Profiler>
           <CertificateGalleryOverlay
@@ -723,7 +780,7 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
             onClose={cameraSystem.exitFocus}
             onNavigateNext={navigateToNextScene}
           />
-          <PhotoLightbox open={photoLightboxOpen} onClose={() => setPhotoLightboxOpen(false)} />
+          <PhotoLightbox open={photoLightboxOpen} onClose={closePhotoLightbox} />
           {projectsResourcesResident && (
             <Suspense fallback={null}>
               <ProjectsOverlay
@@ -741,6 +798,15 @@ function ExperienceContent({ initialPath = "/" }: { initialPath?: string }) {
               <PolaroidCaptionOverlay
                 visible={cameraSystem.selectedScene === "about" && aboutOverlayReady}
                 projectionRef={polaroidProjectionRef}
+              />
+            </Suspense>
+          )}
+          {poemsResourcesResident && (
+            <Suspense fallback={null}>
+              <PoemsOverlay
+                visible={cameraSystem.selectedScene === "poems" && poemsOverlayReady}
+                projectionRef={poemsProjectionRef}
+                onRead={openPoemReader}
               />
             </Suspense>
           )}

--- a/src/scene/Scene.tsx
+++ b/src/scene/Scene.tsx
@@ -20,11 +20,11 @@ import {
 } from "./objects/Primitives";
 import { getCertificateFocusBySlug, type CertificateFocus } from "./objects/certificates";
 import { DEFAULT_RENDER_ISOLATION, type RenderIsolationState } from "./rendering/renderIsolation";
+import { isMobileRenderingViewport } from "./rendering/renderingIntent";
 import { measurePerformanceTask } from "./diagnostics/performance/performanceStore";
 import { useRenderDemand, useRenderSchedulerStore } from "./runtime/render-scheduler";
 
 import type { CinematicNavigationSystem } from "./camera/useCinematicCamera";
-import type { PoemsContentState } from "./content/usePoems";
 import type { ScreenProjectionRef } from "./screenProjection";
 import type { RenderingQualityProfile, ResolvedQualityFeatures } from "./rendering/quality";
 
@@ -58,6 +58,16 @@ const POLAROID_SCREEN_CORNERS: readonly [
   new THREE.Vector3(0.13, -0.185, 0),
   new THREE.Vector3(-0.13, -0.185, 0),
 ];
+
+// Half-extents of the poems notebook page's planeGeometry (0.704 x 0.682
+// scene units) — see PortfolioPoemPreview in objects/Primitives.tsx.
+const POEMS_SCREEN_CORNERS: readonly [THREE.Vector3, THREE.Vector3, THREE.Vector3, THREE.Vector3] =
+  [
+    new THREE.Vector3(-0.352, 0.341, 0),
+    new THREE.Vector3(0.352, 0.341, 0),
+    new THREE.Vector3(0.352, -0.341, 0),
+    new THREE.Vector3(-0.352, -0.341, 0),
+  ];
 
 // Projects a flat mesh's four corners into screen-space pixel coordinates
 // every frame, so an HTML overlay can be perspective-warped (via CSS
@@ -174,8 +184,6 @@ interface SceneProps {
   s: SceneSettings;
   cameraSystem: CinematicNavigationSystem;
   certificateSlug?: string;
-  poemsContent: PoemsContentState;
-  onPoemRead: () => void;
   renderIsolation?: RenderIsolationState;
   qualityProfile: RenderingQualityProfile;
   qualityFeatures: ResolvedQualityFeatures;
@@ -186,6 +194,8 @@ interface SceneProps {
   paperProjectionRef: ScreenProjectionRef;
   polaroidScreenRef: React.MutableRefObject<THREE.Mesh | null>;
   polaroidProjectionRef: ScreenProjectionRef;
+  poemsScreenRef: React.MutableRefObject<THREE.Mesh | null>;
+  poemsProjectionRef: ScreenProjectionRef;
   onPhotoOpen?: () => void;
 }
 
@@ -193,8 +203,6 @@ export function Scene({
   s,
   cameraSystem,
   certificateSlug,
-  poemsContent,
-  onPoemRead,
   renderIsolation = DEFAULT_RENDER_ISOLATION,
   qualityProfile,
   qualityFeatures,
@@ -205,6 +213,8 @@ export function Scene({
   paperProjectionRef,
   polaroidScreenRef,
   polaroidProjectionRef,
+  poemsScreenRef,
+  poemsProjectionRef,
   onPhotoOpen,
 }: SceneProps) {
   const { size } = useThree();
@@ -286,12 +296,8 @@ export function Scene({
         penRotation={s.penRotation}
         paperScreenRef={paperScreenRef}
         photoScreenRef={polaroidScreenRef}
+        poemsScreenRef={poemsScreenRef}
         activeScene={cameraSystem.selectedScene}
-        poemsContent={poemsContent}
-        activePoemSlug={
-          cameraSystem.selectedFocusCollection === "poems" ? cameraSystem.selectedFocusItem : null
-        }
-        onPoemRead={onPoemRead}
         onPhotoOpen={onPhotoOpen}
       />
       <PlanarProjection
@@ -308,7 +314,14 @@ export function Scene({
         projectionRef={polaroidProjectionRef}
         enabled={qualityFeatures.screenProjection}
       />
-      {size.width > 760 && chairMounted && <Chair />}
+      <PlanarProjection
+        label="PoemsScreenProjection"
+        corners={POEMS_SCREEN_CORNERS}
+        screenRef={poemsScreenRef}
+        projectionRef={poemsProjectionRef}
+        enabled={qualityFeatures.screenProjection}
+      />
+      {!isMobileRenderingViewport(size.width / size.height) && chairMounted && <Chair />}
       <Shelf
         illuminated={cameraSystem.selectedScene === "certificates"}
         onCertificateSelect={focusCertificate}

--- a/src/scene/camera/SceneNavigation.tsx
+++ b/src/scene/camera/SceneNavigation.tsx
@@ -19,6 +19,7 @@ interface Props {
   onEnterFocus: (collection: FocusCollectionId, item: string) => unknown;
   onExitFocus: () => unknown;
   poemReaderOpen: boolean;
+  photoLightboxOpen: boolean;
 }
 
 function Arrow({ direction }: { direction: "left" | "right" }) {
@@ -62,6 +63,7 @@ export function SceneNavigation({
   onEnterFocus,
   onExitFocus,
   poemReaderOpen,
+  photoLightboxOpen,
 }: Props) {
   const [introComplete, setIntroComplete] = useState(false);
   const [hasClickedNav, setHasClickedNav] = useState(false);
@@ -124,11 +126,13 @@ export function SceneNavigation({
           above every scene overlay (projects, certificates, poems), rather
           than being trapped inside .canvas-stage's stacking/compositing tree
           alongside JS-positioned (matrix3d-transformed) overlay content. Hidden
-          while a certificate or poem is open full-screen — those overlays have
-          their own close controls and scene navigation doesn't apply there. */}
+          while a certificate, poem, or the about-photo lightbox is open
+          full-screen — those overlays have their own close controls and scene
+          navigation doesn't apply there. */}
       {mounted &&
         selectedFocusCollection !== "certificates" &&
         !poemReaderOpen &&
+        !photoLightboxOpen &&
         createPortal(
           <>
             <button

--- a/src/scene/camera/cameraNavigation.ts
+++ b/src/scene/camera/cameraNavigation.ts
@@ -32,8 +32,12 @@ export function getAdjacentShot(
 export const getAdjacentCameraTarget = getAdjacentShot;
 
 export const isTrackpadPinchOut = (accumulatedDelta: number) => accumulatedDelta >= 48;
+// "about" is excluded alongside focus-collection scenes because its polaroid
+// photo is a clickable canvas object too: R3F's onClick doesn't stop the
+// underlying native touch event from also reaching the window-level tap
+// handler below, so tapping the photo would otherwise also advance the scene.
 export const allowsCanvasTapNavigation = (sceneId: SceneId) =>
-  !SCENE_REGISTRY[sceneId].focusCollection;
+  !SCENE_REGISTRY[sceneId].focusCollection && sceneId !== "about";
 export const isSceneReadyForAutoAdvance = (
   state: Pick<
     CameraNavigationState,

--- a/src/scene/camera/sceneRegistry.ts
+++ b/src/scene/camera/sceneRegistry.ts
@@ -36,7 +36,7 @@ export const SCENE_REGISTRY: Record<SceneId, SceneDefinition> = {
     framing: framing([-3.1, 3.35, 4.9], [-0.15, 1.45, -1.35], 45),
     cameraFocus: { enabled: true, focusDistance: 0.016 },
     transition: { duration: 1 },
-    responsive: { mobile: { position: [-2.55, 3.3, 5.75], lookAt: [-0.1, 1.45, -1.35], fov: 50 } },
+    responsive: { mobile: { position: [-2.55, 3.3, 5.75], lookAt: [-0.1, 1.45, -1.35], fov: 68 } },
   },
   about: {
     id: "about",
@@ -58,7 +58,9 @@ export const SCENE_REGISTRY: Record<SceneId, SceneDefinition> = {
     transition: { duration: 4.3 },
     revisitTransition: { duration: 4.8 },
     returnTransition: { duration: 4.8 },
-    responsive: { mobile: { position: [-1.897, 3.16, -0.578], fov: 46, roll: 0 } },
+    responsive: {
+      mobile: { position: [-1.897, 3.16, -0.578], lookAt: [-2, 1.05, -1.022], fov: 40, roll: 0 },
+    },
   },
   certificates: {
     id: "certificates",

--- a/src/scene/camera/useCinematicCamera.ts
+++ b/src/scene/camera/useCinematicCamera.ts
@@ -157,7 +157,11 @@ export function useCameraTapNavigation(
         return;
       }
       const element = event.target as HTMLElement | null;
-      if (element?.closest("input, textarea, select, button, [contenteditable='true']")) {
+      if (
+        element?.closest(
+          "input, textarea, select, button, [contenteditable='true'], .about-overlay-shell, .poems-overlay-shell",
+        )
+      ) {
         start = null;
         return;
       }

--- a/src/scene/components/PoemReader.tsx
+++ b/src/scene/components/PoemReader.tsx
@@ -335,7 +335,9 @@ export function PoemReader({ open, poems, slug, onSlugChange, onClose }: Props) 
       </button>
       <div className="poem-reader-shell">
         <header className="poem-reader-header">
-          <p className="poem-reader-kicker">Denny K. Schuldt · Poems</p>
+          <p className="poem-reader-kicker">
+            <span className="poem-reader-kicker-full">Denny K. Schuldt · </span>Poems
+          </p>
           <div className="poem-reader-header-actions">
             <button
               type="button"

--- a/src/scene/components/PoemsOverlay.tsx
+++ b/src/scene/components/PoemsOverlay.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { solveHomography } from "../homography";
+import { useWorkingSetStore } from "../runtime/working-set";
+
+import type { ScreenProjectionRef } from "../screenProjection";
+
+// Matches the notebook page's planeGeometry (0.704 x 0.682 scene units) at a
+// uniform 1000 logical px per scene unit, so the overlay maps onto it
+// without distortion.
+const SHEET_LOGICAL_WIDTH = 704;
+const SHEET_LOGICAL_HEIGHT = 682;
+
+export function PoemsOverlay({
+  visible,
+  projectionRef,
+  onRead,
+}: {
+  visible: boolean;
+  projectionRef: ScreenProjectionRef;
+  onRead: () => void;
+}) {
+  const workingSet = useWorkingSetStore();
+  const shellRef = useRef<HTMLDivElement | null>(null);
+  const [present, setPresent] = useState(visible);
+  useEffect(() => {
+    workingSet.resourceEvent("prepare-end", "poems-overlay", {
+      status: "resident",
+      cache: "browser",
+      detail: "lazy module/component mounted",
+    });
+    return () =>
+      workingSet.resourceEvent("release", "poems-overlay", {
+        status: "released",
+        cache: "browser",
+        detail: "component unmounted; JavaScript module remains in browser module cache",
+        evidence: ["unmounted", "references-released", "browser-memory-unverified"],
+      });
+  }, [workingSet]);
+  useEffect(() => {
+    if (visible) {
+      setPresent(true);
+      return;
+    }
+    const timer = window.setTimeout(() => setPresent(false), 480);
+    return () => window.clearTimeout(timer);
+  }, [visible]);
+  useEffect(() => {
+    if (!visible) return;
+    const source = [
+      { x: 0, y: 0 },
+      { x: SHEET_LOGICAL_WIDTH, y: 0 },
+      { x: SHEET_LOGICAL_WIDTH, y: SHEET_LOGICAL_HEIGHT },
+      { x: 0, y: SHEET_LOGICAL_HEIGHT },
+    ];
+    let frame = 0;
+    const update = () => {
+      const shell = shellRef.current,
+        projection = projectionRef.current;
+      if (shell && projection) {
+        const transform = solveHomography(source, projection.points);
+        if (transform) {
+          shell.style.transform = transform;
+          shell.style.visibility = "visible";
+        }
+      }
+      frame = window.requestAnimationFrame(update);
+    };
+    frame = window.requestAnimationFrame(update);
+    return () => window.cancelAnimationFrame(frame);
+  }, [projectionRef, visible]);
+  if (!present) return null;
+  return (
+    <section className={`poems-overlay${visible ? "" : " is-exiting"}`} aria-label="Poems">
+      <div
+        ref={shellRef}
+        className="poems-overlay-shell"
+        style={{
+          width: SHEET_LOGICAL_WIDTH,
+          height: SHEET_LOGICAL_HEIGHT,
+          visibility: "hidden",
+        }}
+      >
+        <h1>Poems</h1>
+        <p>
+          Poetry is how I make sense of what I feel, what I lose, and what I still hope to find.
+        </p>
+        <p>
+          I write about love, absence, identity, time, and the strange experience of being alive.
+        </p>
+        <button type="button" className="poems-overlay-read-button" onClick={onRead}>
+          Read my poetry
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/scene/lighting/Lighting.tsx
+++ b/src/scene/lighting/Lighting.tsx
@@ -28,7 +28,6 @@ export function Lighting({
 }) {
   const aspect = useThree((state) => state.size.width / state.size.height);
   const directionalShadows = shadowsEnabled && features.allShadows && features.directionalShadow;
-  const deskShadows = shadowsEnabled && features.allShadows && features.deskShadow;
   return (
     <>
       {fillEnabled && (
@@ -52,20 +51,6 @@ export function Lighting({
         shadow-bias={-0.00018}
         shadow-radius={RENDERING_INTENT.lighting.sunShadowRadius}
       />
-      <spotLight
-        key={`desk-key:${profile.shadows.deskSpotMapSize}`}
-        name="desk-key"
-        position={[-1.65, 2.95, -0.82]}
-        color="#ffad62"
-        intensity={desk}
-        angle={0.48}
-        penumbra={0.92}
-        distance={7}
-        decay={2}
-        castShadow={deskShadows}
-        shadow-mapSize={[profile.shadows.deskSpotMapSize, profile.shadows.deskSpotMapSize]}
-        shadow-bias={-0.00012}
-      />
       {fillEnabled && (
         <pointLight
           name="desk-fill"
@@ -73,16 +58,6 @@ export function Lighting({
           color="#ff9b50"
           intensity={desk * 0.24}
           distance={2.7}
-          decay={2}
-        />
-      )}
-      {fillEnabled && (
-        <pointLight
-          name="drawer-rim"
-          position={[2.3, 0.65, -1.3]}
-          color="#9d542f"
-          intensity={bounce * RENDERING_INTENT.lighting.drawerRimFactor}
-          distance={3.2}
           decay={2}
         />
       )}

--- a/src/scene/objects/Primitives.tsx
+++ b/src/scene/objects/Primitives.tsx
@@ -27,7 +27,6 @@ import {
   useDestinationWorkingSet,
   useOwnedTexture,
   useOwnedTextures,
-  useWorkingSetStore,
 } from "../runtime/working-set";
 import { useRenderDemand } from "../runtime/render-scheduler";
 import { PHONE_LAYOUT } from "../sceneLayout";
@@ -36,8 +35,6 @@ import { CERTIFICATES, CERTIFICATE_LAYOUT } from "./certificates";
 import type { MutableRefObject, RefObject } from "react";
 import type { RuntimeTaskRegistration } from "@denk/cinematic-navigation";
 import type { SceneId } from "../camera/navigationTypes";
-import type { PoemRecord } from "../content/poems";
-import type { PoemsContentState } from "../content/usePoems";
 import type { RenderReason } from "../runtime/render-scheduler";
 import type { CertificateRecord } from "./certificates";
 
@@ -97,8 +94,6 @@ const DESK_LAMP_DIFFUSER_MATERIAL = new THREE.MeshStandardMaterial({
   color: "#d9b483",
   roughness: 0.72,
   metalness: 0,
-  emissive: "#ff9c4a",
-  emissiveIntensity: 0.58,
 });
 const DESK_LAMP_BASE_GEOMETRY = new THREE.CylinderGeometry(0.28, 0.3, 0.065, 16, 1, false);
 const DESK_LAMP_BASE_INSET_GEOMETRY = new THREE.CylinderGeometry(0.19, 0.22, 0.016, 12, 1, false);
@@ -460,7 +455,6 @@ PORTFOLIO_PAGE_GEOMETRY.center();
 PORTFOLIO_PAGE_GEOMETRY.rotateX(-Math.PI / 2);
 PORTFOLIO_PAGE_GEOMETRY.computeVertexNormals();
 const PORTFOLIO_PAGE_SURFACE_GEOMETRY = new THREE.PlaneGeometry(0.704, 0.682);
-const POEM_READ_CUE_GEOMETRY = new THREE.ShapeGeometry(roundedRectangleShape(0.34, 0.08, 0.04), 8);
 const PORTFOLIO_RING_GEOMETRY = new THREE.TorusGeometry(0.032, 0.007, 4, 8, Math.PI * 1.75);
 // Small washers make the paper-to-ring connection legible at the close reading shot.
 // They sit on the top sheet only; the real binding is carried by the low-poly torus rings.
@@ -867,10 +861,8 @@ interface DeskObjectsProps {
   penRotation: number;
   paperScreenRef?: MutableRefObject<THREE.Mesh | null>;
   photoScreenRef?: MutableRefObject<THREE.Mesh | null>;
+  poemsScreenRef?: MutableRefObject<THREE.Mesh | null>;
   activeScene: SceneId;
-  poemsContent: PoemsContentState;
-  activePoemSlug: string | null;
-  onPoemRead: () => void;
   onPhotoOpen?: () => void;
 }
 
@@ -885,10 +877,8 @@ export function DeskObjects({
   penRotation,
   paperScreenRef,
   photoScreenRef,
+  poemsScreenRef,
   activeScene,
-  poemsContent,
-  activePoemSlug,
-  onPoemRead,
   onPhotoOpen,
 }: DeskObjectsProps) {
   // --------------------------------------------------------------------------
@@ -926,9 +916,7 @@ export function DeskObjects({
           position={folderPosition}
           rotation={folderRotation}
           active={isPoemsActive}
-          poemsContent={poemsContent}
-          activePoemSlug={activePoemSlug}
-          onRead={onPoemRead}
+          screenRef={poemsScreenRef}
         />
       )}
 
@@ -1065,269 +1053,21 @@ function PortfolioPolaroid({ active }: { active: boolean }) {
   );
 }
 
-const POEM_PREVIEW_FONT_SIZE = 34;
-const POEM_PREVIEW_INTRO =
-  "Poetry is how I make sense of what I feel, what I lose, and what I still hope to find.\n\nI write about love, absence, identity, time, and the strange experience of being alive.";
-
-function createPoemPreviewTexture() {
-  const canvas = document.createElement("canvas");
-  canvas.width = 1024;
-  canvas.height = 1160;
-  const context = canvas.getContext("2d");
-  if (!context) return null;
-  context.fillStyle = "#eee4cf";
-  context.fillRect(0, 0, canvas.width, canvas.height);
-  context.textBaseline = "top";
-  context.fillStyle = "#17130f";
-  context.font = '600 72px Georgia, "Times New Roman", serif';
-  context.fillText("Poems", 78, 72, 868);
-  context.fillStyle = "#332a23";
-  context.fillRect(78, 150, 54, 2);
-  context.font = `${POEM_PREVIEW_FONT_SIZE}px Georgia, "Times New Roman", serif`;
-  context.fillStyle = "#211a15";
-  const paragraphs = POEM_PREVIEW_INTRO.split(/\n{2,}/)
-    .map((paragraph) => paragraph.replace(/\s+/g, " ").trim())
-    .filter(Boolean);
-  const lines: string[] = [];
-  for (const paragraph of paragraphs) {
-    const words = paragraph.split(" ");
-    let line = "";
-    for (const word of words) {
-      const candidate = line ? `${line} ${word}` : word;
-      if (line && context.measureText(candidate).width > 868) {
-        lines.push(line);
-        line = word;
-      } else line = candidate;
-    }
-    if (line) lines.push(line);
-    lines.push("");
-  }
-  if (lines.at(-1) === "") lines.pop();
-  const visibleLines = lines.slice(0, 8);
-  if (lines.length > visibleLines.length && visibleLines.length)
-    visibleLines[visibleLines.length - 1] =
-      `${visibleLines[visibleLines.length - 1].replace(/[.…]+$/g, "")}…`;
-  visibleLines.forEach((line, index) =>
-    context.fillText(line, 78, 190 + index * POEM_PREVIEW_FONT_SIZE * 1.3),
-  );
-  context.textAlign = "right";
-  context.textBaseline = "top";
-  context.fillStyle = "#706356";
-  context.font = '24px Georgia, "Times New Roman", serif';
-  context.fillText("Click to read", 946, 1090);
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.colorSpace = THREE.SRGBColorSpace;
-  texture.anisotropy = 8;
-  texture.needsUpdate = true;
-  return texture;
-}
-
-function usePoemPreviewTexture(poem: PoemRecord | null, enabled: boolean) {
-  const workingSet = useWorkingSetStore();
-  const renderDemand = useRenderDemand("poem-preview-texture");
-  const [texture, setTexture] = useState<THREE.CanvasTexture | null>(null);
-  useEffect(() => {
-    if (!enabled) {
-      setTexture(null);
-      return;
-    }
-    workingSet.resourceEvent("prepare-start", "poem-preview-texture", {
-      status: "preparing",
-      cache: "owned",
-      detail: poem?.slug ?? "ambient",
-    });
-    const next = createPoemPreviewTexture();
-    setTexture(next);
-    if (next) {
-      workingSet.resourceEvent("prepare-end", "poem-preview-texture", {
-        status: "resident",
-        cache: "owned",
-        detail: poem?.slug ?? "ambient",
-      });
-      renderDemand.invalidate("asset-ready");
-    }
-    return () => {
-      if (!next) return;
-      next.dispose();
-      workingSet.resourceEvent("dispose", "poem-preview-texture", {
-        status: "released",
-        cache: "owned",
-        detail: "CanvasTexture.dispose() called; renderer/GPU reclamation not directly observable",
-        evidence: [
-          "unmounted",
-          "references-released",
-          "texture-disposed",
-          "browser-memory-unverified",
-          "gpu-memory-unverified",
-        ],
-      });
-    };
-  }, [enabled, poem?.slug, poem?.title, poem?.body, poem?.date, renderDemand, workingSet]);
-  return texture;
-}
-
-function PoemReadCue({
-  active,
-  hovered,
-  onHover,
-  onRead,
-}: {
-  active: boolean;
-  hovered: boolean;
-  onHover: (value: boolean) => void;
-  onRead: () => void;
-}) {
-  const pointerDemand = useRenderDemand("poems-read-cue-pointer");
-  const groupRef = useRef<THREE.Group>(null),
-    backgroundRef = useRef<THREE.MeshBasicMaterial>(null),
-    labelRef = useRef<THREE.MeshBasicMaterial>(null);
-  useMeasuredRuntimeTask({
-    id: "task:poems-read-cue",
-    nodeId: "collection:poems",
-    priority: 6,
-    update: ({ delta }) => {
-      const group = groupRef.current,
-        background = backgroundRef.current,
-        label = labelRef.current;
-      if (group) {
-        const target = active ? (hovered ? 1.08 : 1) : 0.92;
-        group.scale.x = THREE.MathUtils.damp(group.scale.x, target, 7, delta);
-        group.scale.y = THREE.MathUtils.damp(group.scale.y, target, 7, delta);
-      }
-      if (background)
-        background.opacity = THREE.MathUtils.damp(
-          background.opacity,
-          active ? (hovered ? 0.98 : 0.88) : 0,
-          6,
-          delta,
-        );
-      if (label)
-        label.opacity = THREE.MathUtils.damp(
-          label.opacity,
-          active ? (hovered ? 1 : 0.92) : 0,
-          6,
-          delta,
-        );
-    },
-  });
+// The page's title, intro copy, and "read my poetry" cue are HTML (see
+// PoemsOverlay, homography-projected via poemsScreenRef/PlanarProjection in
+// Scene.tsx) rather than a baked CanvasTexture or drei <Text> mesh — same
+// pixelation concern that moved the "About me" body text to HTML. This mesh
+// is just the page's plain paper backdrop.
+function PortfolioPoemPreview({ screenRef }: { screenRef?: MutableRefObject<THREE.Mesh | null> }) {
   return (
-    <group
-      ref={groupRef}
-      visible={active}
-      position={[0.395, 0.078, 0.205]}
+    <mesh
+      ref={screenRef}
+      geometry={PORTFOLIO_PAGE_SURFACE_GEOMETRY}
+      position={[0.395, 0.071, 0]}
       rotation-x={-Math.PI / 2}
-      onPointerOver={(event) => {
-        event.stopPropagation();
-        onHover(true);
-        pointerDemand.invalidate("pointer-interaction");
-      }}
-      onPointerOut={() => {
-        onHover(false);
-        pointerDemand.invalidate("pointer-interaction");
-      }}
-      onClick={(event) => {
-        event.stopPropagation();
-        onRead();
-        pointerDemand.invalidate("pointer-interaction");
-      }}
     >
-      <mesh geometry={POEM_READ_CUE_GEOMETRY}>
-        <meshBasicMaterial
-          ref={backgroundRef}
-          color="#2b211b"
-          transparent
-          opacity={0}
-          depthWrite={false}
-        />
-      </mesh>
-      <Text
-        position={[0, 0, 0.004]}
-        fontSize={0.02}
-        letterSpacing={0.02}
-        anchorX="center"
-        anchorY="middle"
-      >
-        READ MY POETRY
-        <meshBasicMaterial
-          ref={labelRef}
-          color="#f4ecdf"
-          transparent
-          opacity={0}
-          depthWrite={false}
-        />
-      </Text>
-    </group>
-  );
-}
-
-function PortfolioPoemPreview({
-  poem,
-  active,
-  prepare,
-  onRead,
-}: {
-  poem: PoemRecord | null;
-  active: boolean;
-  prepare: boolean;
-  onRead: () => void;
-}) {
-  const pointerDemand = useRenderDemand("poems-preview-pointer");
-  const texture = usePoemPreviewTexture(poem, (active || prepare) && Boolean(poem?.body));
-  const materialRef = useRef<THREE.MeshBasicMaterial>(null);
-  const [hovered, setHovered] = useState(false);
-  useCursor(active && hovered);
-  useMeasuredRuntimeTask({
-    id: "task:poems-preview",
-    nodeId: "collection:poems",
-    priority: 5,
-    update: ({ delta }) => {
-      if (!materialRef.current) return;
-      // The generated canvas texture is asynchronous. Keep the preview dark
-      // until it exists so a newly-mounted active page never flashes white.
-      const channel = THREE.MathUtils.damp(
-        materialRef.current.color.r,
-        active && texture ? 1 : 0.018,
-        3.2,
-        delta,
-      );
-      materialRef.current.color.setRGB(channel, channel, channel);
-    },
-  });
-  return (
-    <>
-      <mesh
-        geometry={PORTFOLIO_PAGE_SURFACE_GEOMETRY}
-        position={[0.395, 0.071, 0]}
-        rotation-x={-Math.PI / 2}
-        onPointerOver={(event) => {
-          if (!active) return;
-          event.stopPropagation();
-          setHovered(true);
-          pointerDemand.invalidate("pointer-interaction");
-        }}
-        onPointerOut={() => {
-          setHovered(false);
-          pointerDemand.invalidate("pointer-interaction");
-        }}
-        onClick={(event) => {
-          if (!active) return;
-          event.stopPropagation();
-          onRead();
-        }}
-      >
-        {/* WebKit can retain the no-map shader variant when a CanvasTexture is
-          attached after the material's first compile. Remounting at that
-          boundary guarantees that Safari compiles the mapped variant. */}
-        <meshBasicMaterial
-          key={texture?.uuid ?? "poem-preview-empty"}
-          ref={materialRef}
-          map={texture}
-          color={active && texture ? "#ffffff" : "#242424"}
-          toneMapped={false}
-        />
-      </mesh>
-      <PoemReadCue active={active} hovered={hovered} onHover={setHovered} onRead={onRead} />
-    </>
+      <meshBasicMaterial color="#eee4cf" toneMapped={false} />
+    </mesh>
   );
 }
 
@@ -1335,19 +1075,14 @@ function PoemsPortfolio({
   position,
   rotation,
   active,
-  poemsContent,
-  activePoemSlug,
-  onRead,
+  screenRef,
 }: {
   position: [number, number];
   rotation: number;
   active: boolean;
-  poemsContent: PoemsContentState;
-  activePoemSlug: string | null;
-  onRead: () => void;
+  screenRef?: MutableRefObject<THREE.Mesh | null>;
 }) {
   useFeatureSettleLease("poems-feature", active, "poems-preview");
-  const poemsWorkingSet = useDestinationWorkingSet("poems");
   const coversRef = useRef<THREE.InstancedMesh>(null),
     liningsRef = useRef<THREE.InstancedMesh>(null),
     pagesRef = useRef<THREE.InstancedMesh>(null);
@@ -1355,11 +1090,6 @@ function PoemsPortfolio({
     eyeletsRef = useRef<THREE.InstancedMesh>(null),
     stitchesRef = useRef<THREE.InstancedMesh>(null);
   const readingLightRef = useRef<THREE.PointLight>(null);
-  const requestedIndex = activePoemSlug
-    ? poemsContent.poems.findIndex(({ slug }) => slug === activePoemSlug)
-    : -1;
-  const activeIndex = requestedIndex >= 0 ? requestedIndex : 0;
-  const activePoem = poemsContent.poems[activeIndex] ?? null;
   const updateReadingLight = useCallback(
     ({ delta }: { delta: number }) => {
       if (readingLightRef.current)
@@ -1478,20 +1208,17 @@ function PoemsPortfolio({
         args={[PORTFOLIO_PAGE_GEOMETRY, PORTFOLIO_PAPER_MATERIAL, 6]}
         castShadow
       />
-      <PortfolioPoemPreview
-        poem={activePoem}
-        active={active}
-        prepare={poemsWorkingSet.state === "preparing"}
-        onRead={onRead}
-      />
-      <pointLight
-        ref={readingLightRef}
-        position={[0.43, 0.62, 0.02]}
-        color="#ffd39a"
-        intensity={0}
-        distance={1.4}
-        decay={2}
-      />
+      <PortfolioPoemPreview screenRef={screenRef} />
+      {active && (
+        <pointLight
+          ref={readingLightRef}
+          position={[0.43, 0.62, 0.02]}
+          color="#ffd39a"
+          intensity={0}
+          distance={1.4}
+          decay={2}
+        />
+      )}
       <instancedMesh
         ref={ringsRef}
         args={[PORTFOLIO_RING_GEOMETRY, PORTFOLIO_METAL_MATERIAL, 6]}
@@ -1533,7 +1260,6 @@ function PhoneScreen({ active }: { active: boolean }) {
   const pointerDemand = useRenderDemand("phone-pointer");
   const texture = useOwnedTexture(withSceneBasePath("/phone.jpeg"), "phone-screen");
   const materialRef = useRef<THREE.MeshBasicMaterial>(null);
-  const lightRef = useRef<THREE.PointLight>(null);
   const [hovered, setHovered] = useState(false);
   if (texture) {
     texture.anisotropy = 8;
@@ -1552,21 +1278,15 @@ function PhoneScreen({ active }: { active: boolean }) {
       const channel = active ? 1 : 0;
       materialRef.current.color.setRGB(channel, channel, channel);
     }
-    if (lightRef.current) lightRef.current.intensity = active ? 0.26 : 0;
   }, [active]);
   const updateScreen = useCallback(
     ({ delta }: { delta: number }) => {
-      const material = materialRef.current,
-        light = lightRef.current;
+      const material = materialRef.current;
       const easing = 16;
       if (material) {
         let channel = THREE.MathUtils.damp(material.color.r, active ? 1 : 0, easing, delta);
         if (!active && channel < 0.001) channel = 0;
         material.color.setRGB(channel, channel, channel);
-      }
-      if (light) {
-        light.intensity = THREE.MathUtils.damp(light.intensity, active ? 0.26 : 0, 12, delta);
-        if (!active && light.intensity < 0.001) light.intensity = 0;
       }
     },
     [active],
@@ -1645,14 +1365,6 @@ function PhoneScreen({ active }: { active: boolean }) {
           </Suspense>
         </group>
       )}
-      <pointLight
-        ref={lightRef}
-        position={[0, 0.11, 0]}
-        color="#dce7f2"
-        intensity={0}
-        distance={0.9}
-        decay={2}
-      />
     </>
   );
 }
@@ -1937,11 +1649,6 @@ function Pen({ position, rotation }: { position: [number, number]; rotation: num
 }
 
 function DeskLamp({ position }: { position: [number, number, number] }) {
-  const lightRef = useRef<THREE.SpotLight>(null);
-  const targetRef = useRef<THREE.Object3D>(null);
-  useEffect(() => {
-    if (lightRef.current && targetRef.current) lightRef.current.target = targetRef.current;
-  }, []);
   return (
     <group position={position} rotation-y={THREE.MathUtils.degToRad(6)} dispose={null}>
       <mesh geometry={DESK_LAMP_BASE_GEOMETRY} position={[0, 0.0325, 0]} castShadow receiveShadow>
@@ -1999,17 +1706,6 @@ function DeskLamp({ position }: { position: [number, number, number] }) {
           <primitive object={DESK_LAMP_DIFFUSER_MATERIAL} attach="material" />
         </mesh>
       </group>
-      <spotLight
-        ref={lightRef}
-        position={[0.31, 1.07, 0]}
-        color="#ffad68"
-        intensity={7.2}
-        distance={2.15}
-        angle={0.55}
-        penumbra={0.86}
-        decay={2}
-      />
-      <object3D ref={targetRef} position={[0.82, 0, 0.28]} />
     </group>
   );
 }
@@ -2638,21 +2334,11 @@ function CertificatePlaceholders() {
 }
 
 function ShelfPracticalLighting({ illuminated }: { illuminated: boolean }) {
-  const lightRefs = useRef<THREE.RectAreaLight[]>([]);
   const ledRefs = useRef<THREE.MeshStandardMaterial[]>([]);
-  const [initialLightIntensity] = useState(() => (illuminated ? 2.35 : 0.01));
   const [initialStripEmission] = useState(() => (illuminated ? 0.018 : 0));
   const updateShelfLighting = useCallback(
     ({ delta }: { delta: number }) => {
       const easing = illuminated ? 0.4 : 0.72;
-      lightRefs.current.forEach((light) => {
-        light.intensity = THREE.MathUtils.damp(
-          light.intensity,
-          illuminated ? 2.35 : 0.01,
-          easing,
-          delta,
-        );
-      });
       ledRefs.current.forEach((material) => {
         material.emissiveIntensity = THREE.MathUtils.damp(
           material.emissiveIntensity,
@@ -2686,18 +2372,6 @@ function ShelfPracticalLighting({ illuminated }: { illuminated: boolean }) {
               roughness={0.76}
             />
           </mesh>
-          <rectAreaLight
-            ref={(light) => {
-              if (light) lightRefs.current[rowIndex] = light;
-            }}
-            name={`shelf-led-row-${rowIndex}`}
-            width={2.22}
-            height={0.035}
-            color="#e6a06d"
-            intensity={initialLightIntensity}
-            position={[0, -0.018, 0.415]}
-            rotation-x={-0.99}
-          />
         </group>
       ))}
     </>

--- a/src/scene/rendering/renderingIntent.ts
+++ b/src/scene/rendering/renderingIntent.ts
@@ -18,14 +18,13 @@ export const RENDERING_INTENT = {
     paperMultisampling: 2,
   },
   lighting: {
-    essentialLights: ["sun-key", "desk-key", "hemisphere-fill", "drawer-rim"] as const,
+    essentialLights: ["sun-key", "hemisphere-fill"] as const,
     // Soft, direction-aware skylight fill standing in for midday daylight —
     // not a flat ambientLight boost. Mobile gets extra lift on top of this
     // because its tighter framing and stronger vignette read darker at the
     // same raw light levels.
     hemisphereDesktopFactor: 0.5,
     hemisphereMobileFactor: 1.75,
-    drawerRimFactor: 0.7,
     // PCF blur-kernel radius for sun-key's shadow (still PCFShadowMap, not
     // PCFSoftShadowMap — that type is deprecated in the installed three.js
     // and silently downgrades with a console warning, see Experience.tsx).

--- a/tests/camera-utils.test.mjs
+++ b/tests/camera-utils.test.mjs
@@ -60,7 +60,7 @@ test("responsive target resolution selects mobile framing", () => {
   assert.equal(getViewportKind(1.8), "desktop");
   assert.equal(resolveCameraTarget("projects", 0.6).fov, 44);
   assert.deepEqual(resolveCameraTarget("about", 0.6).position, [-1.897, 3.16, -0.578]);
-  assert.equal(resolveCameraTarget("about", 0.6).fov, 46);
+  assert.equal(resolveCameraTarget("about", 0.6).fov, 40);
   assert.equal(resolveCameraTarget("about", 0.6).roll, 0);
 });
 
@@ -83,7 +83,7 @@ test("camera navigation resolves adjacent swipe targets", () => {
 
 test("canvas taps leave collection objects in control", () => {
   assert.equal(allowsCanvasTapNavigation("opening"), true);
-  assert.equal(allowsCanvasTapNavigation("about"), true);
+  assert.equal(allowsCanvasTapNavigation("about"), false);
   assert.equal(allowsCanvasTapNavigation("certificates"), false);
   assert.equal(allowsCanvasTapNavigation("projects"), false);
   assert.equal(allowsCanvasTapNavigation("phone"), false);
@@ -281,7 +281,7 @@ test("Scene definitions own camera framing without changing About", () => {
   assert.equal(SCENE_REGISTRY.about.framing.fov, 31);
   assert.equal(SCENE_REGISTRY.about.framing.roll, -25);
   assert.deepEqual(SCENE_REGISTRY.about.responsive.mobile.position, [-1.897, 3.16, -0.578]);
-  assert.equal(SCENE_REGISTRY.about.responsive.mobile.fov, 46);
+  assert.equal(SCENE_REGISTRY.about.responsive.mobile.fov, 40);
   assert.equal(SCENE_REGISTRY.about.responsive.mobile.roll, 0);
   assert.equal(SCENE_REGISTRY.about.responsive.tablet, undefined);
   assert.equal(SCENE_REGISTRY.about.transition.duration, 4.3);

--- a/tests/rendered-html.test.mjs
+++ b/tests/rendered-html.test.mjs
@@ -77,9 +77,7 @@ test("collection focus is explicit and the responsive navigation stays scene-bas
   assert.match(primitives, /bevelSegments: 1/);
   assert.match(primitives, /new THREE\.CylinderGeometry\(0\.026, 0\.026, 1\.18, 8, 1, false\)/);
   assert.doesNotMatch(primitives, /\[-\.48,-\.24,0,\.24,\.48\]\.flatMap/);
-  assert.match(primitives, /shelf-led-row-/);
   assert.match(primitives, /emissiveIntensity=\{initialImageEmission\}/);
-  assert.match(primitives, /intensity=\{initialLightIntensity\}/);
   assert.match(primitives, /ref=\{imageMaterialRef\}\s+map=\{texture\}/s);
   assert.match(primitives, /withSceneBasePath\("\/phone\.jpeg"\)/);
   assert.match(primitives, /PHONE_CONTACT_URL = "https:\/\/wa\.me\/\+593964198839(?:\?[^\"]*)?"/);

--- a/tests/rendering-intent.test.mjs
+++ b/tests/rendering-intent.test.mjs
@@ -31,12 +31,7 @@ test("desktop and mobile preserve the intended renderer and post-processing limi
     RENDERING_INTENT.postProcessing.vignetteDarkness <=
       RENDERING_INTENT.postProcessing.vignetteLimit,
   );
-  assert.deepEqual(RENDERING_INTENT.lighting.essentialLights, [
-    "sun-key",
-    "desk-key",
-    "hemisphere-fill",
-    "drawer-rim",
-  ]);
+  assert.deepEqual(RENDERING_INTENT.lighting.essentialLights, ["sun-key", "hemisphere-fill"]);
 });
 
 test("responsive fill preserves desktop and lifts mobile dark-surface separation", () => {


### PR DESCRIPTION
- Poems scene now renders its title, intro copy, and read CTA as a homography-projected HTML overlay instead of a baked canvas texture and 3D text mesh, matching the About overlay pattern (crisp text at any zoom, no pixelation).
- Tune mobile camera framing for the About and Opening scenes so the content fills the viewport instead of leaving dead space.
- Simplify the poem reader's mobile header to avoid truncation next to the action icons, and fix the comment dialog's centering on mobile.
- Hide the desk chair on mobile using the same aspect-ratio viewport check used elsewhere, instead of an unreliable raw pixel width.
- Remove the desk-key spotlight, drawer-rim light, shelf LED rectAreaLight, and phone screen glow; the poems reading light now only mounts while the poems scene is active.